### PR TITLE
Performing kernel upgrade just prior to initial reboot.

### DIFF
--- a/http/preseed.cfg
+++ b/http/preseed.cfg
@@ -55,3 +55,8 @@ d-i pkgsel/upgrade select full-upgrade
 #d-i time/zone string UTC
 d-i time/zone string US/Pacific
 tasksel tasksel/first multiselect standard, ubuntu-server
+
+# http://superuser.com/questions/580232/ubuntu-12-10-iso-image-customization
+d-i preseed/late_command string \
+	in-target apt-get update ; \
+	in-target apt-get -y dist-upgrade --force-yes ;


### PR DESCRIPTION
#5 By upgrading the kernel just before the initial reboot, the VirtualBox (and VMWare) kernel modules are compiled against the correct version of the kernel.
