### PR TITLE
Bump disk size to 20 GiB for desktop images

### DIFF
--- a/ubuntu1204-desktop.json
+++ b/ubuntu1204-desktop.json
@@ -44,7 +44,7 @@
       "<enter>"
     ],
     "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-    "disk_size": 10140,
+    "disk_size": 21475,
     "vmx_data": {
       "memsize": "1024",
       "numvcpus": "1"
@@ -76,7 +76,7 @@
       "initrd=/install/initrd.gz -- <enter>"
     ],
     "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-    "disk_size": 10140,
+    "disk_size": 21475,
     "vboxmanage": [
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/ubuntu1404-desktop.json
+++ b/ubuntu1404-desktop.json
@@ -44,7 +44,7 @@
       "<enter>"
     ],
     "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-    "disk_size": 10140,
+    "disk_size": 21475,
     "vmx_data": {
       "memsize": "1024",
       "numvcpus": "1"
@@ -76,7 +76,7 @@
       "initrd=/install/initrd.gz -- <enter>"
     ],
     "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-    "disk_size": 10140,
+    "disk_size": 21475,
     "vboxmanage": [
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]


### PR DESCRIPTION
This makes desktop images more suitable for e.g. compiling huge
software and/or libraries like Qt 5.
