### PR TITLE
Puppet installation needs an 'apt-get update'

### DIFF
--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -72,6 +72,7 @@ install_puppet()
     DEB_NAME=puppetlabs-release-${DISTRIB_CODENAME}.deb
     wget http://apt.puppetlabs.com/${DEB_NAME}
     dpkg -i ${DEB_NAME}
+    apt-get update
     if [[ ${CM_VERSION:-} == 'latest' ]]; then
       echo "Installing latest Puppet version"
       apt-get install -y puppet


### PR DESCRIPTION
The puppetlabs-release-${DISTRIB_CODENAME}.deb provides the GPG key and /etc/apt/sources.list.d/puppetlabs.list for the Puppetlabs repository.
Without a proper 'apt-get update' the Puppetlabs packages are not loaded.
