### PR TITLE
Running cm installation after cleanup and adding custom script option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tmp
 Makefile.local
 
 .DS_Store
+
+custom.sh

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ PACKER_VARS_LIST = 'cm=$(CM)' 'headless=$(HEADLESS)' 'update=$(UPDATE)' 'version
 ifdef CM_VERSION
 	PACKER_VARS_LIST += 'cm_version=$(CM_VERSION)'
 endif
+ifdef CUSTOM_SCRIPT
+	PACKER_VARS_LIST += 'custom_script=$(CUSTOM_SCRIPT)'
+endif
 PACKER_VARS := $(addprefix -var , $(PACKER_VARS_LIST))
 ifdef PACKER_DEBUG
 	PACKER := PACKER_LOG=1 packer --debug

--- a/ubuntu1004-i386.json
+++ b/ubuntu1004-i386.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/10.04.4/ubuntu-10.04.4-server-i386.iso",
-    "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe"
+    "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1004-i386",
@@ -163,9 +164,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1004.json
+++ b/ubuntu1004.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/10.04.4/ubuntu-10.04.4-server-amd64.iso",
-    "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6"
+    "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1004",
@@ -163,9 +164,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-desktop.json
+++ b/ubuntu1204-desktop.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.4-alternate-amd64.iso",
-    "iso_checksum": "73a758a2353f21e3016be8135411342a605bccac"
+    "iso_checksum": "73a758a2353f21e3016be8135411342a605bccac",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1204-desktop",
@@ -144,8 +145,9 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
+      "script/cleanup.sh",
       "script/cmtool.sh",
-      "script/cleanup.sh"
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-docker.json
+++ b/ubuntu1204-docker.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
-    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798" 
+    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1204-docker",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-i386.json
+++ b/ubuntu1204-i386.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-i386.iso",
-    "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd"
+    "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1204-i386",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204.json
+++ b/ubuntu1204.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
-    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798"
+    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1204",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-desktop.json
+++ b/ubuntu1404-desktop.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.1-server-amd64.iso",
-    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88"
+    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1404-desktop",
@@ -144,8 +145,9 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
+      "script/cleanup.sh",
       "script/cmtool.sh",
-      "script/cleanup.sh"
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-docker.json
+++ b/ubuntu1404-docker.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.1-server-amd64.iso",
-    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88" 
+    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1404-docker",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-i386.json
+++ b/ubuntu1404-i386.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.1-server-i386.iso",
-    "iso_checksum": "22c6764a4b9335d7b384a081e0fed104236c99d9"
+    "iso_checksum": "22c6764a4b9335d7b384a081e0fed104236c99d9",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1404-i386",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404.json
+++ b/ubuntu1404.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.1-server-amd64.iso",
-    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88"
+    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1404",
@@ -153,9 +154,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410-docker.json
+++ b/ubuntu1410-docker.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.10/ubuntu-14.10-server-amd64.iso",
-    "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b" 
+    "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1410-docker",
@@ -153,9 +154,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410-i386.json
+++ b/ubuntu1410-i386.json
@@ -15,7 +15,8 @@
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
     "iso_url": "http://releases.ubuntu.com/14.10/ubuntu-14.10-server-i386.iso",
-    "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f"
+    "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
+    "custom_script": "."
   },
   "builders": [{
     "vm_name": "ubuntu1410-i386",
@@ -143,9 +144,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410.json
+++ b/ubuntu1410.json
@@ -153,9 +153,10 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh"
+      "script/cleanup.sh",
+      "script/cmtool.sh",
+      "{{ user `custom_script` }}"
     ]
   }],
   "post-processors": [{


### PR DESCRIPTION
In order to ensure the CM tool installs without a hitch all packer files have been updated to run it last.

Another option has also been added which allows a user to run a custom script which is not stored in version control as the final step.
