### PR TITLE
Moved the cleanup to last

### DIFF
--- a/ubuntu1004-i386.json
+++ b/ubuntu1004-i386.json
@@ -165,9 +165,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1004.json
+++ b/ubuntu1004.json
@@ -165,9 +165,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-desktop.json
+++ b/ubuntu1204-desktop.json
@@ -145,9 +145,9 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-docker.json
+++ b/ubuntu1204-docker.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh",
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204-i386.json
+++ b/ubuntu1204-i386.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1204.json
+++ b/ubuntu1204.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-desktop.json
+++ b/ubuntu1404-desktop.json
@@ -72,7 +72,7 @@
     "ssh_username": "{{ user `ssh_username` }}",
     "ssh_password": "{{ user `ssh_password` }}",
     "ssh_wait_timeout": "10000s",
-    "headless": "{{ user `headless` }}",    
+    "headless": "{{ user `headless` }}",
     "boot_command": [
       "<esc><esc><enter><wait>",
       "/install/vmlinuz noapic ",
@@ -145,9 +145,9 @@
       "script/vagrant.sh",
       "script/sshd.sh",
       "script/vmtool.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-docker.json
+++ b/ubuntu1404-docker.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404-i386.json
+++ b/ubuntu1404-i386.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1404.json
+++ b/ubuntu1404.json
@@ -155,9 +155,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410-docker.json
+++ b/ubuntu1410-docker.json
@@ -155,9 +155,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/docker.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410-i386.json
+++ b/ubuntu1410-i386.json
@@ -145,9 +145,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{

--- a/ubuntu1410.json
+++ b/ubuntu1410.json
@@ -155,9 +155,9 @@
       "script/sshd.sh",
       "script/vmtool.sh",
       "script/minimize.sh",
-      "script/cleanup.sh",
       "script/cmtool.sh",
-      "{{ user `custom_script` }}"
+      "{{ user `custom_script` }}",
+      "script/cleanup.sh"
     ]
   }],
   "post-processors": [{


### PR DESCRIPTION
I noticed that the cleanup script was executed prior to the CM tools being setup/installed. I think for a typical box creation you would actually want that to occur at the end of the script process so that the additional apt artifacts get cleaned up.